### PR TITLE
Vram checks

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -53,7 +53,7 @@
         },
         "history-length": {
             "name": "History length",
-            "description": "The length of rewind history stored, in capture frame count.",
+            "description": "The length of rewind history stored, in capture frame count. This will be attempted to be automatically populated on windows machines with Nvidia or AMD graphics cards by the amount of video memory available.",
             "type": "int",
             "min": 20,
             "max": 500,

--- a/mod.json
+++ b/mod.json
@@ -56,7 +56,7 @@
             "description": "The length of rewind history stored, in capture frame count.",
             "type": "int",
             "min": 20,
-            "max": 400,
+            "max": 500,
             "default": {
                 "android": 140,
                 "ios": 140,

--- a/src/hooks/MenuLayer.cpp
+++ b/src/hooks/MenuLayer.cpp
@@ -1,0 +1,52 @@
+#ifdef GEODE_IS_WINDOWS
+#include "MenuLayer.hpp"
+#include <Geode/cocos/platform/third_party/win32/OGLES/GL/glew.h>
+
+// populate defaults by getting amount of system vram
+bool HookedMenuLayer::init() {
+    if (!MenuLayer::init()) return false;
+
+    auto mod = geode::Mod::get();
+
+    bool hasSetRecommended = mod->getSavedValue<bool>("has-set-recommended", false);
+    if (hasSetRecommended) return;
+    mod->setSavedValue<bool>("has-set-recommended", true);
+
+    // https://stackoverflow.com/a/5695427
+    // no intel support very sad
+    auto values = new int[4]();
+    glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, values); // nvidia
+    glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, values); // amd (ati)
+
+    if (values[0] == 0) {
+        geode::log::info("No data returned from vram checks :( ({}, {}, {}, {})", values[0], values[1], values[2], values[3]);
+        delete[] values;
+        return;
+    }
+
+    int kb = values[0];
+    delete[] values;
+    int frames = (kb / 40000) + 20; // https://www.desmos.com/calculator/m2hlel1fjj
+
+    geode::log::info("Video memory checks returned {}kb (approx), mapped to {} frames", kb, frames);
+
+    frames = std::max(20, std::min(frames, 500));
+
+    mod->setSettingValue<int64_t>("history-length", frames);
+
+    auto pop = FLAlertLayer::create(
+        "Rewind",
+        fmt::format(
+            "Rewind has automagically detected {}GB of video memory free, and "
+            "has set the max history length to {}, which can be customised in "
+            "settings.",
+            kb / 1000000, frames
+        ).c_str(),
+        "ok"
+    );
+    pop->m_scene = this;
+    pop->show();
+
+    return true;
+}
+#endif

--- a/src/hooks/MenuLayer.cpp
+++ b/src/hooks/MenuLayer.cpp
@@ -9,23 +9,21 @@ bool HookedMenuLayer::init() {
     auto mod = geode::Mod::get();
 
     bool hasSetRecommended = mod->getSavedValue<bool>("has-set-recommended", false);
-    if (hasSetRecommended) return;
+    if (hasSetRecommended) return true;
     mod->setSavedValue<bool>("has-set-recommended", true);
 
     // https://stackoverflow.com/a/5695427
     // no intel support very sad
-    auto values = new int[4]();
+    int values[4] = {};
     glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, values); // nvidia
     glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, values); // amd (ati)
 
     if (values[0] == 0) {
         geode::log::info("No data returned from vram checks :( ({}, {}, {}, {})", values[0], values[1], values[2], values[3]);
-        delete[] values;
-        return;
+        return true;
     }
 
     int kb = values[0];
-    delete[] values;
     int frames = (kb / 40000) + 20; // https://www.desmos.com/calculator/m2hlel1fjj
 
     geode::log::info("Video memory checks returned {}kb (approx), mapped to {} frames", kb, frames);

--- a/src/hooks/MenuLayer.cpp
+++ b/src/hooks/MenuLayer.cpp
@@ -24,7 +24,7 @@ bool HookedMenuLayer::init() {
     }
 
     int kb = values[0];
-    int frames = (kb / 40000) + 20; // https://www.desmos.com/calculator/m2hlel1fjj
+    int frames = (kb / 42000) + 80; // https://www.desmos.com/calculator/m2hlel1fjj
 
     geode::log::info("Video memory checks returned {}kb (approx), mapped to {} frames", kb, frames);
 
@@ -35,9 +35,9 @@ bool HookedMenuLayer::init() {
     auto pop = FLAlertLayer::create(
         "Rewind",
         fmt::format(
-            "Rewind has automagically detected {}GB of video memory free, and "
-            "has set the max history length to {}, which can be customised in "
-            "settings.",
+            "Rewind has automagically detected <cy>{}GB</c> of video memory free, and "
+            "has set the <cj>max history length</c> to <cy>{}</c>, which can be customised in "
+            "the <co>mod settings</c>.",
             kb / 1000000, frames
         ).c_str(),
         "ok"

--- a/src/hooks/MenuLayer.hpp
+++ b/src/hooks/MenuLayer.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#ifdef GEODE_IS_WINDOWS
+#include <Geode/modify/MenuLayer.hpp>
+
+class $modify(HookedMenuLayer, MenuLayer) {
+    bool init();
+};
+
+#endif

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -20,7 +20,7 @@ $on_mod(Loaded) {
         }
     });
 
-
+#ifdef GEODE_IS_WINDOWS
     // populate defaults by getting amount of system vram
     bool hasSetRecommended = geode::Mod::get()->getSavedValue<bool>("has-set-recommended", false);
     if (hasSetRecommended) return;
@@ -42,4 +42,5 @@ $on_mod(Loaded) {
     geode::log::info("Video memory checks returned {}", values[0]);
 
     delete[] values;
+#endif
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,5 @@
 #include <Geode/loader/SettingV3.hpp>
+#include <Geode/cocos/platform/win32/CCGL.h>
 #include "hooks/GJBaseGameLayer.hpp"
 
 // shouldnt be necessary but i bet some people will be changing their mod settings
@@ -18,4 +19,27 @@ $on_mod(Loaded) {
             fields->m_resolutionMultiplier = geode::Mod::get()->getSettingValue<double>("resolution-multiplier");
         }
     });
-};
+
+
+    // populate defaults by getting amount of system vram
+    bool hasSetRecommended = geode::Mod::get()->getSavedValue<bool>("has-set-recommended", false);
+    if (hasSetRecommended) return;
+
+    geode::Mod::get()->setSavedValue<bool>("has-set-recommended", true);
+
+    // https://stackoverflow.com/a/5695427
+    // some pretty sketchy glgetinteger calls
+    auto values = new int[4]();
+    glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, values);
+    glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, values);
+
+    if (values[0] == 0) {
+        geode::log::info("No data returned from vram checks :( ({}, {}, {}, {})", values[0], values[1], values[2], values[3]);
+        delete[] values;
+        return;
+    }
+
+    geode::log::info("Video memory checks returned {}", values[0]);
+
+    delete[] values;
+}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,5 +1,4 @@
 #include <Geode/loader/SettingV3.hpp>
-#include <Geode/cocos/platform/win32/CCGL.h>
 #include "hooks/GJBaseGameLayer.hpp"
 
 // shouldnt be necessary but i bet some people will be changing their mod settings
@@ -19,28 +18,4 @@ $on_mod(Loaded) {
             fields->m_resolutionMultiplier = geode::Mod::get()->getSettingValue<double>("resolution-multiplier");
         }
     });
-
-#ifdef GEODE_IS_WINDOWS
-    // populate defaults by getting amount of system vram
-    bool hasSetRecommended = geode::Mod::get()->getSavedValue<bool>("has-set-recommended", false);
-    if (hasSetRecommended) return;
-
-    geode::Mod::get()->setSavedValue<bool>("has-set-recommended", true);
-
-    // https://stackoverflow.com/a/5695427
-    // some pretty sketchy glgetinteger calls
-    auto values = new int[4]();
-    glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, values);
-    glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, values);
-
-    if (values[0] == 0) {
-        geode::log::info("No data returned from vram checks :( ({}, {}, {}, {})", values[0], values[1], values[2], values[3]);
-        delete[] values;
-        return;
-    }
-
-    geode::log::info("Video memory checks returned {}", values[0]);
-
-    delete[] values;
-#endif
 }


### PR DESCRIPTION
add vram checks to automatically set history length based on available video memory, on amd and nvidia in menulayer init